### PR TITLE
Update graph_2d.gd

### DIFF
--- a/addons/graph_2d/graph_2d.gd
+++ b/addons/graph_2d/graph_2d.gd
@@ -247,7 +247,7 @@ func remove_plot_item(plot: PlotItem):
 	plot.clear()
 	plot.curve.queue_free()
 	# unreference plot object
-	plot.unreference()
+	plot.call_deferred('unreference')
 	update_legend()
 
 func pixel_to_coordinate(px: Vector2i) -> Vector2:


### PR DESCRIPTION
fix for referencing out of memory item, that causes crash, discussed here: https://github.com/LD2Studio/godot4-graph2d/issues/5