### PR TITLE
Set color to passed color to correctly update legend

### DIFF
--- a/addons/graph_2d/custom_refcounted/plot_item.gd
+++ b/addons/graph_2d/custom_refcounted/plot_item.gd
@@ -40,6 +40,7 @@ func _init(obj, l, c, w):
 	_curve.name = l
 	_curve.color = c
 	_curve.width = w
+	color = c
 	_graph.get_node("PlotArea").add_child(_curve)
 
 


### PR DESCRIPTION
Without this change, the legend on the plots has each plot item's name in white. This will use the colored supplied in Graph2D.add_plot_item(...) to set the legend color to match the curve color.